### PR TITLE
Add support for multiple Java distributions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,21 @@ on:
 
 jobs:
   maven-build:
-    name: "${{ matrix.os }}, jdk-${{ matrix.jdk }}"
+    name: "${{ matrix.os }}, jdk-${{ matrix.jdk }}, ${{ matrix.distribution }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2022]
         jdk: [11, 17]
+        distribution: ["adopt", "temurin", "zulu"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.jdk }}
+      - name: Set up JDK ${{ matrix.jdk }} with ${{ matrix.distribution }} distribution
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.jdk }}
-          distribution: "adopt"
+          distribution: ${{ matrix.distribution }}
           cache: maven
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
This commit enhances the existing GitHub Actions workflow by adding support for multiple Java distributions such as adopt, temurin, and zulu. Now, the Maven build job will run across various combinations of operating systems, JDK versions, and Java distributions. This will help ensure the project can be built and tested across different Java environments, increasing its compatibility and reliability.